### PR TITLE
sets up mysql

### DIFF
--- a/Rails/WebsitesPrototypeBuilder/Gemfile
+++ b/Rails/WebsitesPrototypeBuilder/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '3.2.13'
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
-gem 'sqlite3'
+gem 'mysql2'
 
 # gem for using bootstrap
 gem 'bootstrap-sass'

--- a/Rails/WebsitesPrototypeBuilder/config/database.yml
+++ b/Rails/WebsitesPrototypeBuilder/config/database.yml
@@ -4,22 +4,34 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: Prototyper_development
   pool: 5
-  timeout: 5000
+  username: root
+  password:
+  socket: /var/run/mysqld/mysqld.sock
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: Prototyper_test
   pool: 5
-  timeout: 5000
+  username: root
+  password:
+  socket: /var/run/mysqld/mysqld.sock
 
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
+  adapter: mysql2
+  encoding: utf8
+  reconnect: false
+  database: Prototyper_production
   pool: 5
-  timeout: 5000
+  username: root
+  password:
+  socket: /var/run/mysqld/mysqld.sock


### PR DESCRIPTION
@Malatawy15 
This sets up rails to use mysql
stating the obvious, if u put this on master anyone pulling wont be able to use the database until they INSTALL MYSQL
NOTE:
mysql requires that u explicitly use:
rake db:create
before using
rake db:migrate
for the first time
